### PR TITLE
SG-3 - Demonstrating UpgradeSchema and UpgradeData scripts by adding a gender column and updating the example record

### DIFF
--- a/app/code/Mediotype/Employee/Setup/UpgradeData.php
+++ b/app/code/Mediotype/Employee/Setup/UpgradeData.php
@@ -32,7 +32,7 @@ class UpgradeData implements UpgradeDataInterface
 
         /**
          * Here we check if our module is of version 0.0.2 then update our Joel Hart record. If the version
-         * of our module is less than 0.0.2 version_compare will return -1 and we will know that we need to
+         * of our module is less than 0.0.2 version_compare will return a boolean and we will know that we need to
          * run the following updates.
          */
         if (version_compare($context->getVersion(), '0.0.2', '<')) {

--- a/app/code/Mediotype/Employee/Setup/UpgradeData.php
+++ b/app/code/Mediotype/Employee/Setup/UpgradeData.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @author    Mediotype Development <diveinto@mediotype.com>
+ * @copyright 2019 Mediotype. All Rights Reserved.
+ */
+
+namespace Mediotype\Employee\Setup;
+
+use Magento\Framework\Setup\UpgradeDataInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+
+/**
+ * Upgrade data is used for updating data based on your modules version. Using the version_compare function
+ * we can determine if/when certain changes to the modules data should occur. In this example we are going to
+ * look specifically for our original Joel Hart record from the installation script and update it to have a
+ * value in the newly added gender column.
+ *
+ * Class UpgradeData
+ */
+class UpgradeData implements UpgradeDataInterface
+{
+    /**
+     * @param \Magento\Framework\Setup\ModuleDataSetupInterface $setup
+     * @param \Magento\Framework\Setup\ModuleContextInterface $context
+     */
+    public function upgrade(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
+    {
+        $setup->startSetup();
+
+        $tableName = 'mediotype_employee';
+
+        /**
+         * Here we check if our module is of version 0.0.2 then update our Joel Hart record. If the version
+         * of our module is less than 0.0.2 version_compare will return -1 and we will know that we need to
+         * run the following updates.
+         */
+        if (version_compare($context->getVersion(), '0.0.2', '<')) {
+            $this->updateGender($setup, $tableName);
+        }
+    }
+
+    /**
+     * Updates our record with the correct gender.
+     *
+     * @param \Magento\Framework\Setup\ModuleDataSetupInterface $setup
+     * @param string $tableName
+     */
+    private function updateGender($setup, $tableName)
+    {
+        /**
+         * Check if our row exists in the database.
+         */
+        if ($setup->getTableRow($setup->getTable($tableName), 'employee_id', 1)) {
+            /**
+             * We've confirmed that the row exists in the database, now lets update our users gender to be 1 (male).
+             */
+            $setup->updateTableRow(
+                $setup->getTable($tableName),
+                'employee_id',
+                '1',
+                'gender',
+                '1'
+            );
+        }
+    }
+}

--- a/app/code/Mediotype/Employee/Setup/UpgradeSchema.php
+++ b/app/code/Mediotype/Employee/Setup/UpgradeSchema.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @author    Mediotype Development <diveinto@mediotype.com>
+ * @copyright 2019 Mediotype. All Rights Reserved.
+ */
+
+namespace Mediotype\Employee\Setup;
+
+use Magento\Framework\Setup\UpgradeSchemaInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+
+/**
+ * The UpgradeSchema class is used for updating, removing, adding columns, tables, indexers, etc in the database
+ * based on the version of the module. In the example below we can see that we are performing 2 operations.
+ *
+ * 1. We are checking the module version, when we are on a specific version of a module we only want to run the
+ * latest updates to prevent data corruption. E.G: Upgrading from 0.0.1 -> 0.0.2 we would not want to install the
+ * mediotype_employee table twice and potentially lose all of our added data.
+ *
+ * 2. Adding a column to our already existing table using the SchemaSetupInterface called "gender" to give
+ * our employees a gender.
+ *
+ * Class UpgradeSchema
+ */
+class UpgradeSchema implements UpgradeSchemaInterface
+{
+    /**
+     * @param \Magento\Framework\Setup\SchemaSetupInterface $setup
+     * @param \Magento\Framework\Setup\ModuleContextInterface $context
+     */
+    public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
+    {
+        $setup->startSetup();
+
+        $tableName = 'mediotype_employee';
+
+        /**
+         * Here we check if our module is of version 0.0.2 then update mediotype_employee table to include a
+         * gender column of type smallint. If the version is not of 0.0.2 then the function will return -1 which will result in our code not running.
+         */
+        if (version_compare($context->getVersion(), '0.0.2', '<')) {
+            $this->addGenderColumn($setup, $tableName);
+        }
+
+        $setup->endSetup();
+    }
+
+    /**
+     * Adds the gender column to the mediotype_employee table.
+     *
+     * @param \Magento\Framework\Setup\SchemaSetupInterface $setup
+     * @param $tableName
+     */
+    private function addGenderColumn($setup, $tableName)
+    {
+        $setup->getConnection()->addColumn(
+            $setup->getTable($tableName),
+            'gender',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_SMALLINT,
+                'unsigned' => true,
+                'nullable' => true,
+                'default' => NULL,
+                'comment' => 'Gender'
+            ]
+        );
+    }
+}

--- a/app/code/Mediotype/Employee/etc/module.xml
+++ b/app/code/Mediotype/Employee/etc/module.xml
@@ -21,6 +21,6 @@ has changed and can update the module accordingly (via setup scripts, etc).
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Mediotype_Employee" setup_version="0.0.1">
+    <module name="Mediotype_Employee" setup_version="0.0.2">
     </module>
 </config>


### PR DESCRIPTION
Adding a gender column to the mediotype_employee table and updating our example Joel Hart record in specific with a gender value.

Note: The reason behind not getting a collection and looping through is because we have 1 explicit example record and any data added between versions 0.0.1 and 0.0.2 cannot be assumed to be a single gender.